### PR TITLE
DPI-29026 Package rhtmlPalmTrees in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlPalmTrees";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''R package that combines bar charts and radial plots to generate a palm tree plot.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    jsonlite
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlPalmTrees in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR